### PR TITLE
Use fourseven sass paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,13 @@ meteor add cedla:mdi
 First, add the following line to the top of your main scss file:
 
 ```scss
-@import '.meteor/local/build/programs/server/assets/packages/cedla_mdi/materialdesignicons';
+@import '{cedla:mdi}/materialdesignicons.scss';
 ```
 
 Then, use the syntax below in your HTML files:
 ```html
 <i class="mdi mdi-bell"></i>  <!-- bell -->
 ```
-
-Note: Due to a current limitation of the Meteor packaging system, the above path may not exist the first time you run your Meteor app after installing this package. This will cause an error saying the file to import was not found. This may also occur if you run `meteor reset`. Restarting your app should fix this problem. See [meteor/meteor#2606](https://github.com/meteor/meteor/issues/2606) and [meteor/meteor#2796](https://github.com/meteor/meteor/issues/2796) for more info.
 
 ## Learn More
 

--- a/materialdesignicons.scss
+++ b/materialdesignicons.scss
@@ -1,7 +1,8 @@
-$mdi-font-path: "/packages/cedla_mdi/MaterialDesign-Webfont/fonts" !default;
+@charset "UTF-8";
+$mdi-font-path: "/packages/cedla_mdi/MaterialDesign-WebFont/fonts" !default;
 
-@import "MaterialDesign-WebFont/scss/variables";
-@import "MaterialDesign-WebFont/scss/path";
-@import "MaterialDesign-WebFont/scss/core";
-@import "MaterialDesign-WebFont/scss/icons";
-@import "MaterialDesign-WebFont/scss/extras";
+@import "{cedla:mdi}/MaterialDesign-WebFont/scss/variables.scss";
+@import "{cedla:mdi}/MaterialDesign-WebFont/scss/path.scss";
+@import "{cedla:mdi}/MaterialDesign-WebFont/scss/core.scss";
+@import "{cedla:mdi}/MaterialDesign-WebFont/scss/icons.scss";
+@import "{cedla:mdi}/MaterialDesign-WebFont/scss/extras.scss";

--- a/package.js
+++ b/package.js
@@ -1,32 +1,32 @@
 Package.describe({
     name: 'cedla:mdi',
-    version: '1.2.66',
+    version: '1.2.67',
     summary: 'Material Design Icons font from Templarian (http://materialdesignicons.com/)',
     git: 'https://github.com/cedla/meteor-mdi.git',
     documentation: 'README.md'
 });
 
 Package.onUse(function (api) {
-    api.versionsFrom('1.0');
+    api.versionsFrom('METEOR@1.0');
 
-    api.use("fourseven:scss@3.2.0", ["server"]);
+    api.use("fourseven:scss@3.3.3");
     api.imply("fourseven:scss");
 
-    api.addAssets([
-        'MaterialDesign-Webfont/scss/_core.scss',
-        'MaterialDesign-Webfont/scss/_extras.scss',
-        'MaterialDesign-Webfont/scss/_icons.scss',
-        'MaterialDesign-Webfont/scss/_path.scss',
-        'MaterialDesign-Webfont/scss/_variables.scss',
+    api.addFiles([
+        'MaterialDesign-WebFont/scss/_core.scss',
+        'MaterialDesign-WebFont/scss/_extras.scss',
+        'MaterialDesign-WebFont/scss/_icons.scss',
+        'MaterialDesign-WebFont/scss/_path.scss',
+        'MaterialDesign-WebFont/scss/_variables.scss',
         'materialdesignicons.scss'
-    ], 'server');
+    ], 'client');
 
     api.addAssets([
-        'MaterialDesign-Webfont/fonts/materialdesignicons-webfont.eot',
-        'MaterialDesign-Webfont/fonts/materialdesignicons-webfont.svg',
-        'MaterialDesign-Webfont/fonts/materialdesignicons-webfont.ttf',
-        'MaterialDesign-Webfont/fonts/materialdesignicons-webfont.woff',
-        'MaterialDesign-Webfont/fonts/materialdesignicons-webfont.woff2'
+        'MaterialDesign-WebFont/fonts/materialdesignicons-webfont.eot',
+        'MaterialDesign-WebFont/fonts/materialdesignicons-webfont.svg',
+        'MaterialDesign-WebFont/fonts/materialdesignicons-webfont.ttf',
+        'MaterialDesign-WebFont/fonts/materialdesignicons-webfont.woff',
+        'MaterialDesign-WebFont/fonts/materialdesignicons-webfont.woff2'
     ], 'client');
 
 });


### PR DESCRIPTION
Import with
```
@import '{cedla:mdi}/materialdesignicons.scss'
```

This also fixes the problem where the file does not exist the first time after installing the package.